### PR TITLE
Add superweapon launch music option

### DIFF
--- a/docs/New-or-Enhanced-Logics.md
+++ b/docs/New-or-Enhanced-Logics.md
@@ -1032,6 +1032,17 @@ In `rulesmd.ini`:
 TabIndex=1  ; integer
 ```
 
+### Play theme on superweapon launch
+
+- Superweapons can now trigger a soundtrack theme when fired using `LaunchTheme`.
+  - Provide a soundtrack theme ID to play immediately upon activation.
+
+In `rulesmd.ini`:
+```ini
+[SOMESW]      ; SuperWeaponType
+LaunchTheme=  ; Soundtrack theme ID
+```
+
 ### EMPulse settings
 
 - It is possible to customize which weapon a building with `EMPulseCannon=true` fires when an associated `Type=EMPulse` superweapon (**only** if `EMPulse.TargetSelf=false` or omitted) is fired by setting `EMPulse.WeaponIndex`.

--- a/src/Ext/SWType/Body.cpp
+++ b/src/Ext/SWType/Body.cpp
@@ -47,10 +47,11 @@ void SWTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SW_Next_RealLaunch)
 		.Process(this->SW_Next_IgnoreInhibitors)
 		.Process(this->SW_Next_IgnoreDesignators)
-		.Process(this->SW_Next_RandomWeightsData)
-		.Process(this->SW_Next_RollChances)
-		.Process(this->ShowTimer_Priority)
-		.Process(this->Convert_Pairs)
+                .Process(this->SW_Next_RandomWeightsData)
+                .Process(this->SW_Next_RollChances)
+                .Process(this->ShowTimer_Priority)
+                .Process(this->LaunchTheme)
+                .Process(this->Convert_Pairs)
 		.Process(this->ShowDesignatorRange)
 		.Process(this->TabIndex)
 		.Process(this->UseWeeds)
@@ -108,7 +109,8 @@ void SWTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SW_Next_IgnoreDesignators.Read(exINI, pSection, "SW.Next.IgnoreDesignators");
 	this->SW_Next_RollChances.Read(exINI, pSection, "SW.Next.RollChances");
 
-	this->ShowTimer_Priority.Read(exINI, pSection, "ShowTimer.Priority");
+        this->ShowTimer_Priority.Read(exINI, pSection, "ShowTimer.Priority");
+        this->LaunchTheme = pINI->ReadTheme(pSection, "LaunchTheme", this->LaunchTheme);
 
 	this->EMPulse_WeaponIndex.Read(exINI, pSection, "EMPulse.WeaponIndex");
 	this->EMPulse_SuspendOthers.Read(exINI, pSection, "EMPulse.SuspendOthers");

--- a/src/Ext/SWType/Body.h
+++ b/src/Ext/SWType/Body.h
@@ -56,7 +56,9 @@ public:
 		Valueable<bool> SW_Next_IgnoreDesignators;
 		ValueableVector<float> SW_Next_RollChances;
 
-		Valueable<int> ShowTimer_Priority;
+                Valueable<int> ShowTimer_Priority;
+
+                Valueable<int> LaunchTheme;
 
 		Valueable<WarheadTypeClass*> Detonate_Warhead;
 		Valueable<WeaponTypeClass*> Detonate_Weapon;
@@ -118,10 +120,11 @@ public:
 			, SW_Next_IgnoreInhibitors { false }
 			, SW_Next_IgnoreDesignators { true }
 			, SW_Next_RollChances {}
-			, SW_Next_RandomWeightsData {}
-			, ShowTimer_Priority { 0 }
-			, Convert_Pairs {}
-			, ShowDesignatorRange { true }
+                        , SW_Next_RandomWeightsData {}
+                        , ShowTimer_Priority { 0 }
+                        , LaunchTheme { -1 }
+                        , Convert_Pairs {}
+                        , ShowDesignatorRange { true }
 			, TabIndex { 1 }
 			, UseWeeds { false }
 			, UseWeeds_Amount { RulesClass::Instance->WeedCapacity }

--- a/src/Ext/SWType/FireSuperWeapon.cpp
+++ b/src/Ext/SWType/FireSuperWeapon.cpp
@@ -4,6 +4,7 @@
 #include <BuildingClass.h>
 #include <HouseClass.h>
 #include <ScenarioClass.h>
+#include <ThemeClass.h>
 
 #include <Utilities/EnumFunctions.h>
 #include <Utilities/GeneralUtils.h>
@@ -17,7 +18,10 @@
 
 void SWTypeExt::FireSuperWeaponExt(SuperClass* pSW, const CellStruct& cell)
 {
-	auto const pTypeExt = SWTypeExt::ExtMap.Find(pSW->Type);
+        auto const pTypeExt = SWTypeExt::ExtMap.Find(pSW->Type);
+
+        if(pTypeExt->LaunchTheme >= 0)
+                ThemeClass::Instance.Play(pTypeExt->LaunchTheme);
 
 	if (pTypeExt->LimboDelivery_Types.size() > 0)
 		pTypeExt->ApplyLimboDelivery(pSW->Owner);


### PR DESCRIPTION
## Summary
- add `LaunchTheme` superweapon setting
- use `LaunchTheme` to play a theme when a superweapon fires
- document the new option

## Testing
- `bash scripts/build_debug.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a81d12500832e9fe8bd769108b646